### PR TITLE
Use "python2" instead of "python" in shebangs to follow PEP 394

### DIFF
--- a/get_airport.py
+++ b/get_airport.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python2
 
 import sys
 import requests

--- a/update_apt_file.py
+++ b/update_apt_file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """ Tool to download all airports from X-Plane portal
 """
 


### PR DESCRIPTION
On some systems (e.g. Arch Linux) "python" points to the Python 3 interpreter (which is deliberately incompatible with Python 2, leading to error messages when the scripts are run).

This pull request changes "python" to "python2" in the shebangs so that the scripts are executed by Python 2 on all systems (change in line with [PEP 394](https://www.python.org/dev/peps/pep-0394/)).
